### PR TITLE
[Go SDK] Ability to add custom audience

### DIFF
--- a/rai/client.go
+++ b/rai/client.go
@@ -160,7 +160,7 @@ func (c *Client) AccessToken() (string, error) {
 
 // Fetch a new access token using the given client credentials.
 func (c *Client) GetAccessToken(creds *ClientCredentials) (*AccessToken, error) {
-	audience := fmt.Sprintf("https://%s", c.Host)
+	audience := creds.Audience
 	body := fmt.Sprintf(getAccessTokenBody, creds.ClientID, creds.ClientSecret, audience)
 	req, err := http.NewRequest(http.MethodPost, creds.ClientCredentialsUrl, strings.NewReader(body))
 	if err != nil {

--- a/rai/config.go
+++ b/rai/config.go
@@ -15,6 +15,7 @@
 package rai
 
 import (
+	"fmt"
 	"os/user"
 	"path"
 	"strings"
@@ -92,10 +93,15 @@ func parseConfigStanza(stanza *ini.Section, cfg *Config) error {
 		if v := stanza.Key("client_credentials_url").String(); v != "" {
 			clientCredentialsUrl = v
 		}
+		audience := fmt.Sprintf("https://%s", cfg.Host)
+		if v := stanza.Key("audience").String(); v != "" {
+			audience = v
+		}
 		cfg.Credentials = &ClientCredentials{
 			ClientID:             clientID,
 			ClientSecret:         clientSecret,
-			ClientCredentialsUrl: clientCredentialsUrl}
+			ClientCredentialsUrl: clientCredentialsUrl,
+			Audience:             audience}
 	}
 	return nil
 }

--- a/rai/config.go
+++ b/rai/config.go
@@ -101,7 +101,8 @@ func parseConfigStanza(stanza *ini.Section, cfg *Config) error {
 			ClientID:             clientID,
 			ClientSecret:         clientSecret,
 			ClientCredentialsUrl: clientCredentialsUrl,
-			Audience:             audience}
+			Audience:             audience
+}
 	}
 	return nil
 }

--- a/rai/credentials.go
+++ b/rai/credentials.go
@@ -58,4 +58,5 @@ type ClientCredentials struct {
 	ClientID             string `json:"clientId"`
 	ClientSecret         string `json:"-"`
 	ClientCredentialsUrl string `json:"clientCredentialsUrl"`
+	Audience             string `json:"audience"`
 }


### PR DESCRIPTION
Following the pattern from this [MR](https://github.com/RelationalAI/rai-sdk-python/pull/69), I took the initiative to add the same to the Go SDK.

One important detail is that I'm using the suggested `audience` name, instead of `auth0_audience`. This means it's currently incompatible with the mentioned PR until that one is renamed.