### PR TITLE
Change Table type to []interface{} in ArrowRelation

### DIFF
--- a/rai/models.go
+++ b/rai/models.go
@@ -255,7 +255,7 @@ type TransactionAsyncFile struct {
 
 type ArrowRelation struct {
 	RelationID string
-	Table      interface{}
+	Table      []interface{}
 }
 
 type TransactionAsyncSingleResponse struct {


### PR DESCRIPTION
Arrow response is always column formatted. Changing the `ArrowRelation` table type to `[]interface{}`.