### PR TITLE
Fix the race condition in ExecuteAsync && correctly implement fast-path in Execute()

### DIFF
--- a/examples/execute/main.go
+++ b/examples/execute/main.go
@@ -1,0 +1,71 @@
+// Copyright 2022 RelationalAI, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+
+	"github.com/jessevdk/go-flags"
+	"github.com/relationalai/rai-sdk-go/rai"
+)
+
+type Options struct {
+	Database string `short:"d" long:"database" required:"true" description:"database name"`
+	Engine   string `short:"e" long:"engine" required:"true" descriptio:"engine name"`
+	Code     string `short:"c" long:"code" description:"rel source code"`
+	File     string `short:"f" long:"file" description:"rel source file"`
+	Readonly bool   `long:"readonly" description:"readonly query (default: false)"`
+	Profile  string `long:"profile" default:"default" description:"config profile"`
+}
+
+func getCode(opts *Options) (string, error) {
+	if opts.Code != "" {
+		return opts.Code, nil
+	}
+	bytes, err := ioutil.ReadFile(opts.File)
+	if err != nil {
+		return "", nil
+	}
+	return string(bytes), nil
+}
+
+func run(opts *Options) error {
+	client, err := rai.NewClientFromConfig(opts.Profile)
+	if err != nil {
+		return err
+	}
+	source, err := getCode(opts)
+	if err != nil {
+		return err
+	}
+	rsp, err := client.Execute(opts.Database, opts.Engine, source, nil, opts.Readonly)
+	if err != nil {
+		return err
+	}
+	rai.Print(rsp, 4)
+	return nil
+}
+
+func main() {
+	var opts Options
+	if _, err := flags.ParseArgs(&opts, os.Args); err != nil {
+		os.Exit(1)
+	}
+	if err := run(&opts); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/rai/client.go
+++ b/rai/client.go
@@ -305,7 +305,7 @@ func unmarshal(rsp *http.Response, result interface{}) error {
 		if dstValues.Type() == reflect.TypeOf(TransactionAsyncResult{}) {
 			rsp, err := readTransactionAsyncFiles(data.([]TransactionAsyncFile))
 			rsp.GotCompleteResult = true
-			srcValues := reflect.ValueOf(rsp)
+			srcValues := reflect.ValueOf(*rsp)
 			dstValues.Set(srcValues)
 			return err
 		}

--- a/rai/models.go
+++ b/rai/models.go
@@ -301,8 +301,10 @@ type Source struct {
 }
 
 type TransactionAsyncResult struct {
-	Transaction TransactionAsyncResponse
-	Results     []ArrowRelation
-	Metadata    []TransactionAsyncMetadataResponse
-	Problems    []interface{}
+	// If !GotCompleteResult, keep polling until Transaction reaches terminal State.
+	GotCompleteResult bool
+	Transaction       TransactionAsyncResponse
+	Results           []ArrowRelation
+	Metadata          []TransactionAsyncMetadataResponse
+	Problems          []interface{}
 }


### PR DESCRIPTION
[Fix the race condition in ExecAsync:](https://github.com/RelationalAI/rai-sdk-go/commit/52665ad3729c0e700039fa65f2167a7125b4f93e) 

- Never do more than one HTTP fetch in ExecAsync
- If it's a fast-path, multipart response, use the data that's already
  in the response, instead of fetching it again from the cloud.

[Add fast-path optimization to Execute().](https://github.com/RelationalAI/rai-sdk-go/commit/ce5f053ddf646750d9a6cfd64ac923ebf7a5211d) 

We added a GotCompleteResult boolean to indicate whether or not a
TransactionAsyncResult is a fast-path response or not.

We think all the SDKs should follow this model.

Co-Authored-By: pete.vilter@gmail.com

Fixes: https://github.com/RelationalAI/rai-sdk-go/issues/12