### PR TITLE
show result for v2 protocol

### DIFF
--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -15,6 +15,7 @@
 package rai
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -345,6 +346,13 @@ func TestExecuteAsync(t *testing.T) {
 	expectedProblems := []interface{}{}
 
 	assert.Equal(t, rsp.Problems, expectedProblems)
+
+	// also testing Show v2 result format
+	var io bytes.Buffer
+	rsp.ShowIO(&io)
+	expectedOutput := "/:output/Int64/Int64/Int64/Int64\n1, 1, 1, 1\n2, 4, 8, 16\n3, 9, 27, 81\n4, 16, 64, 256\n5, 25, 125, 625\n\n"
+
+	assert.Equal(t, io.String(), expectedOutput)
 }
 
 func findRelation(relations []Relation, colName string) *Relation {

--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -326,10 +326,10 @@ func TestExecuteAsync(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedResults := []ArrowRelation{
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", []interface{}{1., 2., 3., 4., 5.}},
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", []interface{}{1., 4., 9., 16., 25.}},
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", []interface{}{1., 8., 27., 64., 125.}},
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", []interface{}{1., 16., 81., 256., 625.}},
+		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 2., 3., 4., 5.}}},
+		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 4., 9., 16., 25.}}},
+		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 8., 27., 64., 125.}}},
+		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 16., 81., 256., 625.}}},
 	}
 
 	assert.Equal(t, rsp.Results[0].Table, expectedResults[0].Table)

--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -326,10 +326,12 @@ func TestExecuteAsync(t *testing.T) {
 	assert.Nil(t, err)
 
 	expectedResults := []ArrowRelation{
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 2., 3., 4., 5.}}},
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 4., 9., 16., 25.}}},
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 8., 27., 64., 125.}}},
-		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{{1., 16., 81., 256., 625.}}},
+		ArrowRelation{"/:output/Int64/Int64/Int64/Int64", [][]interface{}{
+			{1., 2., 3., 4., 5.},
+			{1., 4., 9., 16., 25.},
+			{1., 8., 27., 64., 125.},
+			{1., 16., 81., 256., 625.},
+		}},
 	}
 
 	assert.Equal(t, rsp.Results[0].Table, expectedResults[0].Table)

--- a/rai/models.go
+++ b/rai/models.go
@@ -257,7 +257,7 @@ type TransactionAsyncFile struct {
 
 type ArrowRelation struct {
 	RelationID string
-	Table      []interface{}
+	Table      [][]interface{}
 }
 
 type TransactionAsyncSingleResponse struct {

--- a/rai/show.go
+++ b/rai/show.go
@@ -145,10 +145,10 @@ func zip(lists ...[]interface{}) func() []interface{} {
 
 func (tx *TransactionAsyncResult) Show() {
 	for _, r := range tx.Results {
-		k = r.RelationID
-		v = r.Table
+		k := r.RelationID
+		v := r.Table
 		fmt.Println(k)
-		iter := zip(v...)
+		iter := zip(v)
 		for tuple := iter(); tuple != nil; tuple = iter() {
 			for i, element := range tuple {
 				if i > 0 {

--- a/rai/show.go
+++ b/rai/show.go
@@ -144,11 +144,12 @@ func zip(lists ...[]interface{}) func() []interface{} {
 }
 
 func (tx *TransactionAsyncResult) Show() {
+	fmt.Println(tx.Results)
 	for _, r := range tx.Results {
 		k := r.RelationID
 		v := r.Table
 		fmt.Println(k)
-		iter := zip(v)
+		iter := zip(v...)
 		for tuple := iter(); tuple != nil; tuple = iter() {
 			for i, element := range tuple {
 				if i > 0 {

--- a/rai/show.go
+++ b/rai/show.go
@@ -127,3 +127,14 @@ func (tx *TransactionResult) Show() {
 		}
 	}
 }
+
+func (tx *TransactionAsyncResult) Show() {
+	for i, r := range tx.Results {
+		if i > 0 {
+			fmt.Println()
+		}
+
+		fmt.Println(r.RelationID)
+		fmt.Println(r.Table...)
+	}
+}

--- a/rai/show.go
+++ b/rai/show.go
@@ -144,13 +144,9 @@ func zip(lists ...[]interface{}) func() []interface{} {
 }
 
 func (tx *TransactionAsyncResult) Show() {
-	res := make(map[string][][]interface{})
-
 	for _, r := range tx.Results {
-		res[r.RelationID] = append(res[r.RelationID], r.Table)
-	}
-
-	for k, v := range res {
+		k = r.RelationID
+		v = r.Table
 		fmt.Println(k)
 		iter := zip(v...)
 		for tuple := iter(); tuple != nil; tuple = iter() {

--- a/rai/show.go
+++ b/rai/show.go
@@ -129,12 +129,20 @@ func (tx *TransactionResult) Show() {
 }
 
 func (tx *TransactionAsyncResult) Show() {
-	for i, r := range tx.Results {
-		if i > 0 {
+	output := make(map[string][]interface{})
+
+	for _, r := range tx.Results {
+		output[r.RelationID] = append(output[r.RelationID], r.Table)
+	}
+
+	for k, v := range output {
+		fmt.Println(k)
+		for _, r := range v {
+			for _, c := range r.([]interface{}) {
+				fmt.Print(c, " ")
+			}
 			fmt.Println()
 		}
-
-		fmt.Println(r.RelationID)
-		fmt.Println(r.Table...)
+		fmt.Println()
 	}
 }

--- a/rai/show.go
+++ b/rai/show.go
@@ -153,13 +153,13 @@ func (tx *TransactionAsyncResult) Show() {
 	for k, v := range res {
 		fmt.Println(k)
 		iter := zip(v...)
-		for tuples := iter(); tuples != nil; tuples = iter() {
-			for i, tuple := range tuples {
+		for tuple := iter(); tuple != nil; tuple = iter() {
+			for i, element := range tuple {
 				if i > 0 {
 					fmt.Print(", ")
 				}
 
-				fmt.Print(tuple)
+				fmt.Print(element)
 			}
 			fmt.Println()
 		}

--- a/rai/show.go
+++ b/rai/show.go
@@ -128,18 +128,38 @@ func (tx *TransactionResult) Show() {
 	}
 }
 
+func zip(lists ...[]interface{}) func() []interface{} {
+	zip := make([]interface{}, len(lists))
+	i := 0
+	return func() []interface{} {
+		for j := range lists {
+			if i >= len(lists[j]) {
+				return nil
+			}
+			zip[j] = lists[j][i]
+		}
+		i++
+		return zip
+	}
+}
+
 func (tx *TransactionAsyncResult) Show() {
-	output := make(map[string][]interface{})
+	res := make(map[string][][]interface{})
 
 	for _, r := range tx.Results {
-		output[r.RelationID] = append(output[r.RelationID], r.Table)
+		res[r.RelationID] = append(res[r.RelationID], r.Table)
 	}
 
-	for k, v := range output {
+	for k, v := range res {
 		fmt.Println(k)
-		for _, r := range v {
-			for _, c := range r.([]interface{}) {
-				fmt.Print(c, " ")
+		iter := zip(v...)
+		for tuples := iter(); tuples != nil; tuples = iter() {
+			for i, tuple := range tuples {
+				if i > 0 {
+					fmt.Print(", ")
+				}
+
+				fmt.Print(tuple)
 			}
 			fmt.Println()
 		}

--- a/rai/show.go
+++ b/rai/show.go
@@ -143,23 +143,26 @@ func zip(lists ...[]interface{}) func() []interface{} {
 	}
 }
 
-func (tx *TransactionAsyncResult) Show() {
-	fmt.Println(tx.Results)
+func (tx *TransactionAsyncResult) ShowIO(io io.Writer) {
 	for _, r := range tx.Results {
 		k := r.RelationID
 		v := r.Table
-		fmt.Println(k)
+		fmt.Fprintf(io, "%s\n", k)
 		iter := zip(v...)
 		for tuple := iter(); tuple != nil; tuple = iter() {
 			for i, element := range tuple {
 				if i > 0 {
-					fmt.Print(", ")
+					fmt.Fprint(io, ", ")
 				}
 
-				fmt.Print(element)
+				fmt.Fprintf(io, "%v", element)
 			}
-			fmt.Println()
+			fmt.Fprintln(io)
 		}
-		fmt.Println()
+		fmt.Fprintln(io)
 	}
+}
+
+func (tx *TransactionAsyncResult) Show() {
+	tx.ShowIO(os.Stdout)
 }


### PR DESCRIPTION
This PR add support to show result for v2 protocol.

Example `rsp.Show() for def output:x = 1;2;3 def output:y = "bar"`
```
/:output/:x/Int64
1 2 3

/:output/:y/String
bar
```