### PR TITLE
Disable oauth client test

### DIFF
--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -564,8 +564,9 @@ func findOAuthClient(clients []OAuthClient, id string) *OAuthClient {
 	return nil
 }
 
+// TODO: keep it disabled until we fix the Auth0 API rate limiting issue
 // Test OAuth Client APIs.
-func TestOAuthClient(t *testing.T) {
+/*func TestOAuthClient(t *testing.T) {
 	client := test.client
 
 	rsp, err := client.FindOAuthClient(test.oauthClient)
@@ -614,7 +615,7 @@ func TestOAuthClient(t *testing.T) {
 	rsp, err = client.FindOAuthClient(test.oauthClient)
 	assert.Nil(t, err)
 	assert.Nil(t, rsp)
-}
+}*/
 
 func findUser(users []User, id string) *User {
 	for _, user := range users {


### PR DESCRIPTION
Disable `OAuthClient` test until `Auth0` rate limit is fixed