### PR TITLE
Fix for https://relationalai.atlassian.net/browse/RAI-9265 - Failed to create user as it already exists

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.18
 
 require (
 	github.com/apache/arrow/go/v7 v7.0.0
+	github.com/google/uuid v1.1.2
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/pkg/errors v0.9.1
 	github.com/shopspring/decimal v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -136,6 +136,7 @@ github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=

--- a/rai/main_test.go
+++ b/rai/main_test.go
@@ -188,7 +188,7 @@ func TestMain(m *testing.M) {
 	// Using a common email address can create user creation or deletion issues in edge cases -
 	// when tests run in parallel on multiple machines, for example, the CI/CD workflows.
 	// Context: https://relationalai.atlassian.net/browse/RAI-9265
-	userEmail := fmt.Sprintf("%s@relational.ai", uuid.New().String())
+	userEmail := fmt.Sprintf("rai-sdk-go-%s@relational.ai", uuid.New().String())
 	flag.StringVar(&test.databaseName, "d", "rai-sdk-go", "test database name")
 	flag.StringVar(&test.engineName, "e", "rai-sdk-go", "test engine name")
 	flag.StringVar(&test.engineSize, "s", "S", "test engine size")

--- a/rai/main_test.go
+++ b/rai/main_test.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
 )
 
@@ -183,11 +184,16 @@ func tearDown(client *Client) {
 func TestMain(m *testing.M) {
 	var err error
 
+	// Generating a random email address.
+	// Using a common email address can create user creation or deletion issues in edge cases -
+	// when tests run in parallel on multiple machines, for example, the CI/CD workflows.
+	// Context: https://relationalai.atlassian.net/browse/RAI-9265
+	userEmail := fmt.Sprintf("%s@relational.ai", uuid.New().String())
 	flag.StringVar(&test.databaseName, "d", "rai-sdk-go", "test database name")
 	flag.StringVar(&test.engineName, "e", "rai-sdk-go", "test engine name")
 	flag.StringVar(&test.engineSize, "s", "S", "test engine size")
 	flag.StringVar(&test.oauthClient, "c", "rai-sdk-go", "test OAuth client name")
-	flag.StringVar(&test.userEmail, "u", "rai-sdk-go@relational.ai", "test user name")
+	flag.StringVar(&test.userEmail, "u", userEmail, "test user name")
 	flag.BoolVar(&test.noTeardown, "no-teardown", false, "don't teardown test resources")
 	flag.BoolVar(&test.showQuery, "show-query", false, "display query string")
 	flag.Parse()


### PR DESCRIPTION
Fix for https://relationalai.atlassian.net/browse/RAI-9265
Since we were using a common/fixed email address and all the CI/CD workflows use the same account, user-service failed to create the user with fixed email address again because another workflow had already created it in parallel.