### PR TITLE
[RAI-13018] Update AutoNumber test type

### DIFF
--- a/rai/results.go
+++ b/rai/results.go
@@ -1420,7 +1420,7 @@ func newConstColumn(t ConstType, nrows int) Column {
 	if matchPrefix(t, "rel", "base", "_") {
 		switch t[2].(string) {
 		case "AutoNumber":
-			return newLiteralColumn(t[3].(int64), nrows)
+			return newLiteralColumn(t[3].(uint64), nrows)
 		case "Date":
 			d := DateFromRataDie(t[3].(int64))
 			return newLiteralColumn(d, nrows)
@@ -1534,7 +1534,7 @@ func newBuiltinValueColumn(vt ValueType, c Column, nrows int) Column {
 	if matchPrefix(vt, "rel", "base", "_") {
 		switch vt[2].(string) {
 		case "AutoNumber":
-			return c // primitiveColumn[int64]
+			return c // primitiveColumn[uint64]
 		case "Date":
 			return newDateColumn(c.(DataColumn[int64]))
 		case "DateTime":
@@ -1833,7 +1833,7 @@ func builtinType(vt ValueType) reflect.Type {
 	if matchPrefix(vt, "rel", "base", "_") {
 		switch vt[2].(string) {
 		case "AutoNumber":
-			return Int64Type
+			return UInt64Type
 		case "Date":
 			return TimeType
 		case "DateTime":
@@ -1860,7 +1860,7 @@ func builtinValue(ct ConstType) any {
 	if matchPrefix(ct, "rel", "base", "_") {
 		switch ct[2].(string) {
 		case "AutoNumber":
-			return ct[3].(int64)
+			return ct[3].(uint64)
 		case "Date":
 			return DateFromRataDie(ct[3].(int64))
 		case "DateTime":

--- a/rai/results.go
+++ b/rai/results.go
@@ -1420,7 +1420,7 @@ func newConstColumn(t ConstType, nrows int) Column {
 	if matchPrefix(t, "rel", "base", "_") {
 		switch t[2].(string) {
 		case "AutoNumber":
-			return newLiteralColumn(t[3].(int64), nrows)
+			return newLiteralColumn(t[3].(uint64), nrows)
 		case "Date":
 			d := DateFromRataDie(t[3].(int64))
 			return newLiteralColumn(d, nrows)
@@ -1534,7 +1534,7 @@ func newBuiltinValueColumn(vt ValueType, c Column, nrows int) Column {
 	if matchPrefix(vt, "rel", "base", "_") {
 		switch vt[2].(string) {
 		case "AutoNumber":
-			return c // primitiveColumn[int64]
+			return c // primitiveColumn[uint64]
 		case "Date":
 			return newDateColumn(c.(DataColumn[int64]))
 		case "DateTime":
@@ -1833,7 +1833,7 @@ func builtinType(vt ValueType) reflect.Type {
 	if matchPrefix(vt, "rel", "base", "_") {
 		switch vt[2].(string) {
 		case "AutoNumber":
-			return Int64Type
+			return Uint64Type
 		case "Date":
 			return TimeType
 		case "DateTime":
@@ -1860,7 +1860,7 @@ func builtinValue(ct ConstType) any {
 	if matchPrefix(ct, "rel", "base", "_") {
 		switch ct[2].(string) {
 		case "AutoNumber":
-			return ct[3].(int64)
+			return ct[3].(uint64)
 		case "Date":
 			return DateFromRataDie(ct[3].(int64))
 		case "DateTime":

--- a/rai/results.go
+++ b/rai/results.go
@@ -1420,7 +1420,7 @@ func newConstColumn(t ConstType, nrows int) Column {
 	if matchPrefix(t, "rel", "base", "_") {
 		switch t[2].(string) {
 		case "AutoNumber":
-			return newLiteralColumn(t[3].(uint64), nrows)
+			return newLiteralColumn(t[3].(int64), nrows)
 		case "Date":
 			d := DateFromRataDie(t[3].(int64))
 			return newLiteralColumn(d, nrows)
@@ -1534,7 +1534,7 @@ func newBuiltinValueColumn(vt ValueType, c Column, nrows int) Column {
 	if matchPrefix(vt, "rel", "base", "_") {
 		switch vt[2].(string) {
 		case "AutoNumber":
-			return c // primitiveColumn[uint64]
+			return c // primitiveColumn[int64]
 		case "Date":
 			return newDateColumn(c.(DataColumn[int64]))
 		case "DateTime":
@@ -1833,7 +1833,7 @@ func builtinType(vt ValueType) reflect.Type {
 	if matchPrefix(vt, "rel", "base", "_") {
 		switch vt[2].(string) {
 		case "AutoNumber":
-			return UInt64Type
+			return Int64Type
 		case "Date":
 			return TimeType
 		case "DateTime":
@@ -1860,7 +1860,7 @@ func builtinValue(ct ConstType) any {
 	if matchPrefix(ct, "rel", "base", "_") {
 		switch ct[2].(string) {
 		case "AutoNumber":
-			return ct[3].(uint64)
+			return ct[3].(int64)
 		case "Date":
 			return DateFromRataDie(ct[3].(int64))
 		case "DateTime":

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -250,9 +250,9 @@ var primitiveTypeTests = []execTest{
 	{
 		query: `def output = auto_number[1]`,
 		mdata: mdata("0.arrow", sig("output", Int64Type,
-			vtype("rel:base:AutoNumber", Int64Type))),
+			vtype("rel:base:AutoNumber", Uint64Type))),
 		pdata: xdata("0.arrow", sig(Int64Type, Uint64Type), nil), // value changes on each call
-		rdata: xdata("0.arrow", sig("output", Int64Type, Int64Type), nil),
+		rdata: xdata("0.arrow", sig("output", Int64Type, Uint64Type), nil),
 	},
 	{
 		query: `def output = int[8, 12], int[8, -12]`,

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -250,7 +250,7 @@ var primitiveTypeTests = []execTest{
 	{
 		query: `def output = auto_number[1]`,
 		mdata: mdata("0.arrow", sig("output", Int64Type,
-			vtype("rel:base:AutoNumber", Uint64Type))),
+			vtype("rel:base:AutoNumber", nil))), // TODO (dba) AutoNumber was incorrectly tagged as having an `Int64Type` until the change in the engine is in prod we need to keep it as `nil`.
 		pdata: xdata("0.arrow", sig(Int64Type, Uint64Type), nil), // value changes on each call
 		rdata: xdata("0.arrow", sig("output", Int64Type, Uint64Type), nil),
 	},

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -250,7 +250,7 @@ var primitiveTypeTests = []execTest{
 	{
 		query: `def output = auto_number[1]`,
 		mdata: mdata("0.arrow", sig("output", Int64Type,
-			vtype("rel:base:AutoNumber", nil))), // TODO (dba) AutoNumber was incorrectly tagged as having an `Int64Type` until the change in the engine is in prod we need to keep it as `nil`.
+			vtype("rel:base:AutoNumber", nil))), // TODO (dba) AutoNumber was incorrectly tagged as having an `Int64Type`. Until the change in the engine is in prod, we need to keep it as `nil`.
 		pdata: xdata("0.arrow", sig(Int64Type, Uint64Type), nil), // value changes on each call
 		rdata: xdata("0.arrow", sig("output", Int64Type, Uint64Type), nil),
 	},

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -249,8 +249,9 @@ var primitiveTypeTests = []execTest{
 	},
 	{
 		query: `def output = auto_number[1]`,
-		mdata: mdata("0.arrow", sig("output", Int64Type,
-			vtype("rel:base:AutoNumber", nil))), // TODO (dba) AutoNumber was incorrectly tagged as having an `Int64Type`. Until the change in the engine is in prod, we need to keep it as `nil`.
+		// TODO (dba) AutoNumber was incorrectly tagged as having an `Int64Type`. Until the change in the engine is in prod, we need to keep it as `nil`.
+		// mdata: mdata("0.arrow", sig("output", Int64Type,
+		// 	vtype("rel:base:AutoNumber", Uint64Type))), 
 		pdata: xdata("0.arrow", sig(Int64Type, Uint64Type), nil), // value changes on each call
 		rdata: xdata("0.arrow", sig("output", Int64Type, Uint64Type), nil),
 	},


### PR DESCRIPTION
Update `AutoNumber` metadata test caser to reflect upcoming changes in the engine.