### PR TITLE
Cenerating X-Request-Id for all HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+* `X-Request-Id` is generated for every HTTP request.
+* Stringified `HTTPError` includes the `X-Request-Id` instead of all headers from the response.
+
 ## v0.5.9-alpha
 * Increased auth token expiration token from 5s to 60s.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.5.10-alpha
 * `X-Request-Id` is generated for every HTTP request.
 * Stringified `HTTPError` includes the `X-Request-Id` instead of all headers from the response.
 

--- a/rai/version.go
+++ b/rai/version.go
@@ -14,4 +14,4 @@
 
 package rai
 
-const Version = "0.5.9-alpha"
+const Version = "0.5.10-alpha"


### PR DESCRIPTION
- Passing an SDK generated `X-Request-Id` to all HTTP requests
- Using `X-Request-Id` in `HTTPError` instead of all headers from the response