### PR TITLE
Remove auto_number test

### DIFF
--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -248,14 +248,6 @@ var primitiveTypeTests = []execTest{
 			[][]any{{"output", "output"}, {int64(2), int64(3)}}),
 	},
 	{
-		query: `def output = auto_number[1]`,
-		// TODO (dba) AutoNumber was incorrectly tagged as having an `Int64Type`. Until the change in the engine is in prod, we need to keep it as `nil`.
-		// mdata: mdata("0.arrow", sig("output", Int64Type,
-		// 	vtype("rel:base:AutoNumber", Uint64Type))), 
-		pdata: xdata("0.arrow", sig(Int64Type, Uint64Type), nil), // value changes on each call
-		rdata: xdata("0.arrow", sig("output", Int64Type, Uint64Type), nil),
-	},
-	{
 		query: `def output = int[8, 12], int[8, -12]`,
 		mdata: mdata("0.arrow", sig("output", Int8Type, Int8Type)),
 		pdata: xdata("0.arrow", sig(Int8Type, Int8Type), row(int8(12), int8(-12))),


### PR DESCRIPTION
In next week's release we are dropping support for `auto_number` as part of the surface area reduction initiative. This PR removes a test case that would likely break the SDK tests then.