### PR TITLE
RAI-22855 fix issues with (u)int128 within value types

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -2,6 +2,9 @@ name: build/test
 
 on:
   push:
+    branches: [main]
+  pull_request:
+    branches: [main]
   schedule:
     - cron: '30 5 * * *'
 

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -6,6 +6,7 @@ on:
       - '*'
   schedule:
     - cron: '30 5 * * *'
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -2,9 +2,8 @@ name: build/test
 
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    branches:
+      - '*'
   schedule:
     - cron: '30 5 * * *'
 

--- a/rai/results.go
+++ b/rai/results.go
@@ -103,6 +103,9 @@ type Tabular interface {
 	Strings(int) []string
 }
 
+// TabularSlice is an interface for columns that contain array data that can
+// be sliced into sub-arrays, combining the sub-array's values to represent
+// values such as int128
 type TabularSlice interface {
 	Tabular
 	ColumnSlice(int, int) Column
@@ -1640,7 +1643,8 @@ func newSimpleValueColumn(vt ValueType, c Column, nrows int) Column {
 	return valueColumn{cols}
 }
 
-// get the corresponding width of an Arrow array column for this part of a Signature
+// getSliceWidth gets the corresponding width of an Arrow array column for
+// a `t` that is one of the parts of a Signature
 func getSliceWidth(t any) int {
 	switch tt := t.(type) {
 	case reflect.Type:
@@ -1693,7 +1697,7 @@ func newTabularValueColumn(vt ValueType, c Tabular, nrows int) Column {
 				cc = newRelationColumn(tt, c.Column(ncol), nrows)
 				ncol++
 			case ValueType:
-				cc = newValueColumn(tt, c.Column(ncol) /* listCol */, nrows)
+				cc = newValueColumn(tt, c.Column(ncol), nrows)
 				ncol++
 			case string:
 				cc = newSymbolColumn(tt, nrows)

--- a/rai/results.go
+++ b/rai/results.go
@@ -103,6 +103,11 @@ type Tabular interface {
 	Strings(int) []string
 }
 
+type TabularSlice interface {
+	Tabular
+	ColumnSlice(int, int) Column
+}
+
 type Relation interface {
 	Tabular
 	Showable
@@ -273,6 +278,8 @@ type listColumn[T any] struct {
 	cols  []Column
 }
 
+var _ TabularSlice = &listColumn[int]{}
+
 func (c listColumn[T]) Column(cnum int) Column {
 	return listItemColumn[T]{c.data, cnum, c.ncols}
 }
@@ -285,6 +292,13 @@ func (c listColumn[T]) Columns() []Column {
 		}
 	}
 	return c.cols
+}
+
+func (c listColumn[T]) ColumnSlice(cnum int, width int) Column {
+	if width == 1 {
+		return listItemColumn[T]{c.data, cnum, c.ncols}
+	}
+	return listSliceColumn[T]{c.data, cnum, width, c.ncols}
 }
 
 func (c listColumn[T]) GetItem(rnum int, out []T) {
@@ -428,6 +442,58 @@ func (c listItemColumn[T]) Type() any {
 }
 
 func (c listItemColumn[T]) Value(rnum int) any {
+	return c.Item(rnum)
+}
+
+// Represents several sub-columns of a `listColumn` that represent one column for a composite type (e.g. int128)
+type listSliceColumn[T any] struct {
+	data  []T
+	cnum  int
+	width int
+	ncols int
+}
+
+var _ TabularColumn[int] = &listSliceColumn[int]{}
+
+func (c listSliceColumn[T]) Item(rnum int) []T {
+	out := make([]T, c.width)
+	c.GetItem(rnum, out)
+	return out
+}
+
+func (c listSliceColumn[T]) GetItem(rnum int, out []T) {
+	roffs := rnum * c.ncols
+	for i := 0; i < c.width; i++ {
+		out[i] = c.data[roffs+c.cnum+i]
+	}
+}
+
+func (c listSliceColumn[T]) NumCols() int {
+	return 1
+}
+
+func (c listSliceColumn[T]) Strings(rnum int) []string {
+	roffs := rnum * c.ncols
+	result := make([]string, c.width)
+	for i := 0; i < c.width; i++ {
+		result[i] = asString(c.data[roffs+c.cnum+i])
+	}
+	return result
+}
+
+func (c listSliceColumn[T]) NumRows() int {
+	return len(c.data) / c.ncols
+}
+
+func (c listSliceColumn[T]) String(rnum int) string {
+	return asString(c.Item(rnum))
+}
+
+func (c listSliceColumn[T]) Type() any {
+	return typeOf[T]()
+}
+
+func (c listSliceColumn[T]) Value(rnum int) any {
 	return c.Item(rnum)
 }
 
@@ -1544,7 +1610,7 @@ func newBuiltinValueColumn(vt ValueType, c Column, nrows int) Column {
 		case "FixedDecimal":
 			return newDecimalColumn(vt, c)
 		case "Hash":
-			return newUint128Column(c.(listColumn[uint64]))
+			return newUint128Column(c.(TabularColumn[uint64]))
 		case "Rational":
 			return newRationalColumn(c)
 		case "Missing":
@@ -1574,27 +1640,70 @@ func newSimpleValueColumn(vt ValueType, c Column, nrows int) Column {
 	return valueColumn{cols}
 }
 
+// get the corresponding width of an Arrow array column for this part of a Signature
+func getSliceWidth(t any) int {
+	switch tt := t.(type) {
+	case reflect.Type:
+		switch tt {
+		case Int128Type:
+		case Uint128Type:
+			return 2
+		default:
+			return 1
+		}
+	case ValueType:
+		ret := 0
+		for _, st := range t.(ValueType) {
+			ret += getSliceWidth(st)
+		}
+		return ret
+	}
+	return 0
+}
+
 // Projects a valueColumn from an underlying `Tabular` column.
 func newTabularValueColumn(vt ValueType, c Tabular, nrows int) Column {
 	ncol := 0
-	ncols := len(vt)
-	cols := make([]Column, ncols)
-	for i, t := range vt {
-		var cc Column
-		switch tt := t.(type) {
-		case reflect.Type:
-			cc = newRelationColumn(tt, c.Column(ncol), nrows)
-			ncol++
-		case ValueType:
-			cc = newValueColumn(tt, c.Column(ncol), nrows)
-			ncol++
-		case string:
-			cc = newSymbolColumn(tt, nrows)
-		default:
-			cc = newLiteralColumn(tt, nrows)
+	tcols := len(vt)
+	cols := make([]Column, tcols)
+
+	if tsc, ok := c.(TabularSlice); ok {
+		for i, t := range vt {
+			sliceWidth := getSliceWidth(t)
+			var cc Column
+			switch tt := t.(type) {
+			case reflect.Type:
+				cc = newRelationColumn(tt, tsc.ColumnSlice(ncol, sliceWidth), nrows)
+				ncol++
+			case ValueType:
+				cc = newValueColumn(tt, tsc.ColumnSlice(ncol, sliceWidth), nrows)
+				ncol++
+			case string:
+				cc = newSymbolColumn(tt, nrows)
+			default:
+				cc = newLiteralColumn(tt, nrows)
+			}
+			cols[i] = cc
 		}
-		cols[i] = cc
+	} else {
+		for i, t := range vt {
+			var cc Column
+			switch tt := t.(type) {
+			case reflect.Type:
+				cc = newRelationColumn(tt, c.Column(ncol), nrows)
+				ncol++
+			case ValueType:
+				cc = newValueColumn(tt, c.Column(ncol) /* listCol */, nrows)
+				ncol++
+			case string:
+				cc = newSymbolColumn(tt, nrows)
+			default:
+				cc = newLiteralColumn(tt, nrows)
+			}
+			cols[i] = cc
+		}
 	}
+
 	return valueColumn{cols}
 }
 

--- a/rai/results.go
+++ b/rai/results.go
@@ -1678,10 +1678,10 @@ func newTabularValueColumn(vt ValueType, c Tabular, nrows int) Column {
 			switch tt := t.(type) {
 			case reflect.Type:
 				cc = newRelationColumn(tt, tsc.ColumnSlice(ncol, sliceWidth), nrows)
-				ncol++
+				ncol += sliceWidth
 			case ValueType:
 				cc = newValueColumn(tt, tsc.ColumnSlice(ncol, sliceWidth), nrows)
-				ncol++
+				ncol += sliceWidth
 			case string:
 				cc = newSymbolColumn(tt, nrows)
 			default:

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -1896,7 +1896,7 @@ func TestConstValueTypes(t *testing.T) {
 }
 
 func TestValueTypes(t *testing.T) {
-	//runTests(t, valueTypeTests)
+	runTests(t, valueTypeTests)
 	runTests(t, extraValueTypeTests)
 }
 

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -1296,6 +1296,7 @@ var extraValueTypeTests = []execTest{
 			row("output", value("Foo", "Bar", "MyType", int64(12), int64(34)))),
 	},
 	// There is a bug with nested value types
+	// RAI-23484
 	/*
 		{
 			query: `

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -1295,8 +1295,7 @@ var extraValueTypeTests = []execTest{
 			sig("output", vtype("Foo", "Bar", "MyType", Int64Type, Int64Type)),
 			row("output", value("Foo", "Bar", "MyType", int64(12), int64(34)))),
 	},
-	// There is a bug with nested value types
-	// RAI-23484
+	// RAI-23484 There is a bug with nested value types
 	/*
 		{
 			query: `


### PR DESCRIPTION
Handle the case where there are composite values (i.e. large values represented by multiple arrow columns) within value types.