### PR TITLE
Add println to client.execute for debug purposes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
-## v0.5.13-alpha
+## v0.5.14-alpha
 * Added print outs for client.execute.
+
+## v0.5.13-alpha
+* Fix (u)int128/hash handling.
 
 ## v0.5.12-alpha
 * Add beta version of snowflake datastream APIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog
 
+## v0.5.13-alpha
+* Added print outs for client.execute.
+
 ## v0.5.12-alpha
-* Add beta version of snowflake datastream APIs. 
+* Add beta version of snowflake datastream APIs.
 
 ## v0.5.11-alpha
-* Add ability to start and stop engines. 
+* Add ability to start and stop engines.
 
 ## v0.5.10-alpha
 * `X-Request-Id` is generated for every HTTP request.

--- a/rai/client.go
+++ b/rai/client.go
@@ -974,6 +974,7 @@ func (c *Client) Execute(
 		return nil, err
 	}
 	if isTransactionComplete(&rsp.Transaction) {
+		fmt.Println(fmt.Sprintf("Txn state: %s.", rsp.Transaction.State))
 		return rsp, nil // fast path
 	}
 	id := rsp.Transaction.ID
@@ -985,13 +986,17 @@ func (c *Client) Execute(
 			return nil, err
 		}
 		if isTransactionComplete(&rsp.Transaction) {
+			fmt.Println(fmt.Sprintf("Txn %s state: %s.", id, rsp.Transaction.State))
 			return rsp, nil
 		}
-		delta := time.Since(t0)                  // total run time
+		fmt.Println(fmt.Sprintf("Txn %s state: %s.", id, rsp.Transaction.State))
+		delta := time.Since(t0) // total run time
+		fmt.Println(fmt.Sprintf("Delta is %s.", delta))
 		pause := time.Duration(int64(delta) / 5) // 20% of total run time
 		if pause > twoMinutes {
 			pause = twoMinutes
 		}
+		fmt.Println(fmt.Sprintf("Pause took %s.", pause))
 		time.Sleep(pause)
 	}
 }

--- a/rai/client.go
+++ b/rai/client.go
@@ -974,7 +974,7 @@ func (c *Client) Execute(
 		return nil, err
 	}
 	if isTransactionComplete(&rsp.Transaction) {
-		fmt.Println(fmt.Sprintf("Txn state: %s.", rsp.Transaction.State))
+		fmt.Printf("Txn state: %s.\n", rsp.Transaction.State)
 		return rsp, nil // fast path
 	}
 	id := rsp.Transaction.ID
@@ -986,17 +986,17 @@ func (c *Client) Execute(
 			return nil, err
 		}
 		if isTransactionComplete(&rsp.Transaction) {
-			fmt.Println(fmt.Sprintf("Txn %s state: %s.", id, rsp.Transaction.State))
+			fmt.Printf("Txn %s state: %s.", id, rsp.Transaction.State)
 			return rsp, nil
 		}
-		fmt.Println(fmt.Sprintf("Txn %s state: %s.", id, rsp.Transaction.State))
+		fmt.Printf("Txn %s state: %s.", id, rsp.Transaction.State)
 		delta := time.Since(t0) // total run time
-		fmt.Println(fmt.Sprintf("Delta is %s.", delta))
+		fmt.Printf("Delta is %s.", delta)
 		pause := time.Duration(int64(delta) / 5) // 20% of total run time
 		if pause > twoMinutes {
 			pause = twoMinutes
 		}
-		fmt.Println(fmt.Sprintf("Pause took %s.", pause))
+		fmt.Printf("Pause took %s.", pause)
 		time.Sleep(pause)
 	}
 }


### PR DESCRIPTION
As per [NCDNTS-3452](https://relationalai.atlassian.net/browse/NCDNTS-3452) this attempts to add some "telemetry" to the `client.execute` method so that the consuming service can report on and use it for reproducing the issue.

[NCDNTS-3452]: https://relationalai.atlassian.net/browse/NCDNTS-3452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ