### PR TITLE
Adjust test to check for intrinsics

### DIFF
--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -207,18 +207,18 @@ func TestDatabase(t *testing.T) {
 	modelNames, err := client.ListModelNames(test.databaseName, test.engineName)
 	assert.Nil(t, err)
 	assert.True(t, len(modelNames) > 0)
-	assert.True(t, contains(modelNames, "rel/solverlib"))
+	assert.True(t, contains(modelNames, "rel/core-intrinsics"))
 
 	models, err := client.ListModels(test.databaseName, test.engineName)
 	assert.Nil(t, err)
 	assert.True(t, len(models) > 0)
-	model := findModel(models, "rel/solverlib")
+	model := findModel(models, "rel/core-intrinsics")
 	assert.NotNil(t, model)
 	if model != nil {
 		assert.True(t, len(model.Value) > 0)
 	}
 
-	model, err = client.GetModel(test.databaseName, test.engineName, "rel/solverlib")
+	model, err = client.GetModel(test.databaseName, test.engineName, "rel/core-intrinsics")
 	assert.Nil(t, err)
 	assert.NotNil(t, model)
 	if model != nil {

--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -207,18 +207,18 @@ func TestDatabase(t *testing.T) {
 	modelNames, err := client.ListModelNames(test.databaseName, test.engineName)
 	assert.Nil(t, err)
 	assert.True(t, len(modelNames) > 0)
-	assert.True(t, contains(modelNames, "rel/stdlib"))
+	assert.True(t, contains(modelNames, "pkg/std/std/common"))
 
 	models, err := client.ListModels(test.databaseName, test.engineName)
 	assert.Nil(t, err)
 	assert.True(t, len(models) > 0)
-	model := findModel(models, "rel/stdlib")
+	model := findModel(models, "pkg/std/std/common")
 	assert.NotNil(t, model)
 	if model != nil {
 		assert.True(t, len(model.Value) > 0)
 	}
 
-	model, err = client.GetModel(test.databaseName, test.engineName, "rel/stdlib")
+	model, err = client.GetModel(test.databaseName, test.engineName, "pkg/std/std/common")
 	assert.Nil(t, err)
 	assert.NotNil(t, model)
 	if model != nil {

--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -207,18 +207,18 @@ func TestDatabase(t *testing.T) {
 	modelNames, err := client.ListModelNames(test.databaseName, test.engineName)
 	assert.Nil(t, err)
 	assert.True(t, len(modelNames) > 0)
-	assert.True(t, contains(modelNames, "pkg/std/std/common"))
+	assert.True(t, contains(modelNames, "rel/solverlib"))
 
 	models, err := client.ListModels(test.databaseName, test.engineName)
 	assert.Nil(t, err)
 	assert.True(t, len(models) > 0)
-	model := findModel(models, "pkg/std/std/common")
+	model := findModel(models, "rel/solverlib")
 	assert.NotNil(t, model)
 	if model != nil {
 		assert.True(t, len(model.Value) > 0)
 	}
 
-	model, err = client.GetModel(test.databaseName, test.engineName, "pkg/std/std/common")
+	model, err = client.GetModel(test.databaseName, test.engineName, "rel/solverlib")
 	assert.Nil(t, err)
 	assert.NotNil(t, model)
 	if model != nil {


### PR DESCRIPTION
The test was checking for `rel/stdlib`, which was moved to `pkg/std/std/common` with the new `std` package. We now test for `rel/core-intrinsics` because it's still there and will unlikely move.