### PR TITLE
Adding '@function' to some definitions to force correct key/values

### DIFF
--- a/rai/client_test.go
+++ b/rai/client_test.go
@@ -310,7 +310,7 @@ func TestEngine(t *testing.T) {
 func TestExecuteV1(t *testing.T) {
 	client := test.client
 
-	query := "def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4"
+	query := "@function def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4"
 
 	rsp, err := client.ExecuteV1(test.databaseName, test.engineName, query, nil, true)
 	assert.Nil(t, err)
@@ -334,7 +334,7 @@ func TestExecuteV1(t *testing.T) {
 func TestListTransactions(t *testing.T) {
 	client := test.client
 
-	query := "def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4"
+	query := "@function def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4"
 	txn, err := client.Execute(test.databaseName, test.engineName, query, nil, true)
 	assert.Nil(t, err)
 
@@ -358,7 +358,7 @@ func TestListTransactions(t *testing.T) {
 func TestListTransactionsByTag(t *testing.T) {
 	client := test.client
 
-	query := "def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4"
+	query := "@function def output(x, x2, x3, x4): {1; 2; 3; 4; 5}(x) and x2 = x^2 and x3 = x^3 and x4 = x^4"
 	tag := fmt.Sprintf("rai-sdk-go:%s", uuid.New().String())
 	txn, err := client.Execute(test.databaseName, test.engineName, query, nil, true, tag)
 	assert.Nil(t, err)

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -2094,7 +2094,7 @@ func pick(r Relation, ncol int, v any) []any {
 
 func TestRelationSlice(t *testing.T) {
 	query := `
-	  @no_diagnostics(:FUNCTION_ON_METAVALUE)	@function def output {
+	  @no_diagnostics(:FUNCTION_ON_METAVALUE) @function def output {
 			(1, :foo, "a");
 			(2, :bar, "c");
 			(3, :baz, 42);

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -2094,7 +2094,7 @@ func pick(r Relation, ncol int, v any) []any {
 
 func TestRelationSlice(t *testing.T) {
 	query := `
-		@function def output {
+	  @no_diagnostics(:FUNCTION_ON_METAVALUE)	@function def output {
 			(1, :foo, "a");
 			(2, :bar, "c");
 			(3, :baz, 42);
@@ -2174,7 +2174,7 @@ func TestRelationSlice(t *testing.T) {
 
 func TestRelationUnion(t *testing.T) {
 	query := `
-		@function def output {
+		@no_diagnostics(:FUNCTION_ON_METAVALUE) @function def output {
 			(1, :foo, "a");
 			(2, :bar, "c");
 			(3, :baz, 42);

--- a/rai/results_test.go
+++ b/rai/results_test.go
@@ -2032,7 +2032,7 @@ func TestInterfaceTypes(t *testing.T) {
 }
 
 func TestPrefixMatch(t *testing.T) {
-	query := `def output {(1, :foo, "a"); (42, :bar, "c")}`
+	query := `@function def output {(1, :foo, "a"); (42, :bar, "c")}`
 
 	rsp, err := test.client.Execute(test.databaseName, test.engineName, dindent(query), nil, true, o11yTag)
 	assert.Nil(t, err)
@@ -2094,7 +2094,7 @@ func pick(r Relation, ncol int, v any) []any {
 
 func TestRelationSlice(t *testing.T) {
 	query := `
-		def output {
+		@function def output {
 			(1, :foo, "a");
 			(2, :bar, "c");
 			(3, :baz, 42);
@@ -2174,7 +2174,7 @@ func TestRelationSlice(t *testing.T) {
 
 func TestRelationUnion(t *testing.T) {
 	query := `
-		def output {
+		@function def output {
 			(1, :foo, "a");
 			(2, :bar, "c");
 			(3, :baz, 42);


### PR DESCRIPTION
RAICode PR https://github.com/RelationalAI/raicode/pull/23464 made FD inference more precise changing the output relkey